### PR TITLE
update composer.json to make ot compatible with Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
    "minimum-stability": "stable",
    "require": {
     "php": ">=5.5.9",
+    "laravel/framework": "5.5.*",
     "illuminate/support": "5.2.*",
     "guzzlehttp/guzzle": "~5.0"
    },


### PR DESCRIPTION
Make package compatible with Laravel 5.5. 
`  Problem 1
    - Installation request for unicodeveloper/laravel-ngsc ^1.0 -> satisfiable by unicodeveloper/laravel-ngsc[1.0.0].
    - Conclusion: remove laravel/framework v5.5.40
    - Conclusion: don't install laravel/framework v5.5.40
    - unicodeveloper/laravel-ngsc 1.0.0 requires illuminate/support 5.2.* -> satisfiable by illuminate/support[v5.2.0, v5.2.19, v5.2.21, v5.2.24, v5.2.25, v5.2.26, v5.2.27, v5.2.28, v5.2.31, v5.2.32, v5.2.37, v5.2.43, v5.2.45, v5.2.6, v5.2.7].
    - don't install illuminate/support v5.2.43|don't install laravel/framework v5.5.40
    - don't install illuminate/support v5.2.45|don't install laravel/framework v5.5.40
    - don't install illuminate/support v5.2.0|don't install laravel/framework v5.5.40
    - don't install illuminate/support v5.2.19|don't install laravel/framework v5.5.40
    - don't install illuminate/support v5.2.21|don't install laravel/framework v5.5.40
    - don't install illuminate/support v5.2.24|don't install laravel/framework v5.5.40
    - don't install illuminate/support v5.2.25|don't install laravel/framework v5.5.40
    - don't install illuminate/support v5.2.26|don't install laravel/framework v5.5.40
    - don't install illuminate/support v5.2.27|don't install laravel/framework v5.5.40
    - don't install illuminate/support v5.2.28|don't install laravel/framework v5.5.40
    - don't install illuminate/support v5.2.31|don't install laravel/framework v5.5.40
    - don't install illuminate/support v5.2.32|don't install laravel/framework v5.5.40
    - don't install illuminate/support v5.2.37|don't install laravel/framework v5.5.40
    - don't install illuminate/support v5.2.6|don't install laravel/framework v5.5.40
    - don't install illuminate/support v5.2.7|don't install laravel/framework v5.5.40
    - Installation request for laravel/framework (locked at v5.5.40, required as 5.5.*) -> satisfiable by laravel/framework[v5.5.40].`